### PR TITLE
process_elimination_round rpc

### DIFF
--- a/src/components/ColorPicker/index.module.scss
+++ b/src/components/ColorPicker/index.module.scss
@@ -223,3 +223,81 @@
   max-width: 360px;
   position: relative;
 }
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 20px;
+}
+
+.modal {
+  background-color: shared.$background-dark;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  width: 100%;
+  max-width: 360px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.modalTitle {
+  font-size: 1.25rem;
+  font-weight: normal;
+  text-align: center;
+  margin: 0;
+  color: shared.$text-color;
+}
+
+.modalContent {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.confirmRow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-align: center;
+}
+
+.confirmLabel {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.confirmValue {
+  font-size: 1.1rem;
+  color: shared.$text-color;
+}
+
+.modalButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 10px;
+
+  .button {
+    width: 100%;
+    margin: 0;
+  }
+
+  .cancelButton {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: shared.$text-color;
+    border-color: rgba(255, 255, 255, 0.3);
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.15);
+    }
+  }
+}

--- a/src/components/ColorPicker/index.tsx
+++ b/src/components/ColorPicker/index.tsx
@@ -48,6 +48,20 @@ function ColorPicker({ session }: { session: ISession }) {
   );
   const isAdmin = userData.color === session.admin_color;
   const [isSaving, setIsSaving] = useState(false);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+
+  const getStrategyDisplayName = (strategy: string) => {
+    switch (strategy) {
+      case "elimination":
+        return "elimination";
+      case "ranked_choice":
+        return "ranked choice";
+      case "simple_vote":
+        return "simple vote";
+      default:
+        return strategy;
+    }
+  };
 
   useEffect(() => {
     if (session) {
@@ -239,13 +253,48 @@ function ColorPicker({ session }: { session: ISession }) {
                     <div className={styles.buttonGroup}>
                       <button
                         className={styles.button}
-                        onClick={() => handleAllHere()}
+                        onClick={() => setShowConfirmModal(true)}
                         disabled={isSaving}
                       >
                         we're all here
                       </button>
                     </div>
                   </div>
+
+                  {showConfirmModal && (
+                    <div className={styles.modalOverlay} onClick={() => setShowConfirmModal(false)}>
+                      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+                        <h3 className={styles.modalTitle}>confirm settings</h3>
+                        <div className={styles.modalContent}>
+                          <div className={styles.confirmRow}>
+                            <span className={styles.confirmLabel}>voting strategy:</span>
+                            <span className={styles.confirmValue}>{getStrategyDisplayName(selectedStrategy)}</span>
+                          </div>
+                          <div className={styles.confirmRow}>
+                            <span className={styles.confirmLabel}>nominations per person:</span>
+                            <span className={styles.confirmValue}>{allowedNoms}</span>
+                          </div>
+                        </div>
+                        <div className={styles.modalButtons}>
+                          <button
+                            className={`${styles.button} ${styles.cancelButton}`}
+                            onClick={() => setShowConfirmModal(false)}
+                          >
+                            go back
+                          </button>
+                          <button
+                            className={styles.button}
+                            onClick={() => {
+                              setShowConfirmModal(false);
+                              handleAllHere();
+                            }}
+                          >
+                            confirm
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
                 </>
               ) : (
                 <div className={styles.nonAdminMessage}>

--- a/src/components/EliminationVoting/index.tsx
+++ b/src/components/EliminationVoting/index.tsx
@@ -31,6 +31,8 @@ function EliminationVoting({ session }: { session: ISession }) {
     strategy: 'elimination'
   });
 
+  const isAdmin = userData.color === session.admin_color;
+
   if (sendToResults) {
     return null;
   }
@@ -57,22 +59,26 @@ function EliminationVoting({ session }: { session: ISession }) {
 
   // Bottom action content for after voting
   const bottomActionContent = showTieOptions ? (
-    <>
-      <button
-        className={styles.button}
-        onClick={startTiebreakerRound}
-        disabled={isLoading}
-      >
-        start tie-breaker round
-      </button>
-      <button
-        className={`${styles.button} ${styles.dark}`}
-        onClick={acceptMultipleWinners}
-        disabled={isLoading}
-      >
-        accept multiple winners
-      </button>
-    </>
+    isAdmin ? (
+      <>
+        <button
+          className={styles.button}
+          onClick={startTiebreakerRound}
+          disabled={isLoading}
+        >
+          start tie-breaker round
+        </button>
+        <button
+          className={`${styles.button} ${styles.dark}`}
+          onClick={acceptMultipleWinners}
+          disabled={isLoading}
+        >
+          accept multiple winners
+        </button>
+      </>
+    ) : (
+      <div className={styles.waitingMessage}>waiting for admin to decide what to do next...</div>
+    )
   ) : nextRoundFilms.length > 1 ? (
     <button
       className={styles.button}

--- a/src/components/EliminationVoting/index.tsx
+++ b/src/components/EliminationVoting/index.tsx
@@ -80,21 +80,29 @@ function EliminationVoting({ session }: { session: ISession }) {
       <div className={styles.waitingMessage}>waiting for admin to decide what to do next...</div>
     )
   ) : nextRoundFilms.length > 1 ? (
-    <button
-      className={styles.button}
-      onClick={handleElimination}
-      disabled={isLoading}
-    >
-      {isLoading ? "processing..." : "next round"}
-    </button>
+    isAdmin ? (
+      <button
+        className={styles.button}
+        onClick={handleElimination}
+        disabled={isLoading}
+      >
+        {isLoading ? "processing..." : "next round"}
+      </button>
+    ) : (
+      <div className={styles.waitingMessage}>waiting for admin to start next round...</div>
+    )
   ) : (
-    <button
-      className={`${styles.button} ${styles.dark}`}
-      onClick={() => acceptSingleWinner()}
-      disabled={isLoading}
-    >
-      {isLoading ? "processing..." : "see results"}
-    </button>
+    isAdmin ? (
+      <button
+        className={`${styles.button} ${styles.dark}`}
+        onClick={() => acceptSingleWinner()}
+        disabled={isLoading}
+      >
+        {isLoading ? "processing..." : "see results"}
+      </button>
+    ) : (
+      <div className={styles.waitingMessage}>waiting for admin to show results...</div>
+    )
   );
 
   return (

--- a/src/components/Lobby/index.tsx
+++ b/src/components/Lobby/index.tsx
@@ -127,7 +127,6 @@ export default function Lobby() {
         <button
           className={`${styles.button} ${styles.primary}`}
           onClick={createNewSession}
-          disabled={true}
         >
           start new session
         </button>
@@ -138,10 +137,10 @@ export default function Lobby() {
             placeholder={"enter session code..."}
             value={gameId}
             onChange={(e) => setGameId(e.target.value)}
-            disabled={true}
+            disabled={isJoiningSession}
           />
-          <button className={`${styles.button} ${styles.dark}`} type="submit" disabled={true}>
-            start with code
+          <button className={`${styles.button} ${styles.dark}`} type="submit" disabled={isJoiningSession || !gameId}>
+            {isJoiningSession ? "joining..." : "start with code"}
           </button>
         </form>
       </div>

--- a/src/components/RankedChoiceVoting/index.module.scss
+++ b/src/components/RankedChoiceVoting/index.module.scss
@@ -262,4 +262,15 @@
 
 .button:hover {
   background-color: var(--primary-dark);
+}
+
+.adminWaitingMessage {
+  text-align: center;
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-style: italic;
+  padding: 0 20px;
+  max-width: 100%;
+  box-sizing: border-box;
 } 

--- a/src/components/RankedChoiceVoting/index.tsx
+++ b/src/components/RankedChoiceVoting/index.tsx
@@ -28,6 +28,8 @@ function RankedChoiceVoting({ session }: { session: ISession }) {
     strategy: 'ranked_choice'
   });
 
+  const isAdmin = userData.color === session.admin_color;
+
   // Handle reordering
   const handleMoveFilm = (filmTitle: string, direction: 'up' | 'down') => {
     if (!rankings || currUserVoted) return;
@@ -63,20 +65,24 @@ function RankedChoiceVoting({ session }: { session: ISession }) {
               </div>
             ))}
           </div>
-          <div className={styles.tieButtons}>
-            <button 
-              onClick={startTiebreakerRound}
-              className={styles.button}
-            >
-              Start Tiebreaker Round
-            </button>
-            <button 
-              onClick={acceptMultipleWinners}
-              className={styles.button}
-            >
-              Accept All as Winners
-            </button>
-          </div>
+          {isAdmin ? (
+            <div className={styles.tieButtons}>
+              <button 
+                onClick={startTiebreakerRound}
+                className={styles.button}
+              >
+                Start Tiebreaker Round
+              </button>
+              <button 
+                onClick={acceptMultipleWinners}
+                className={styles.button}
+              >
+                Accept All as Winners
+              </button>
+            </div>
+          ) : (
+            <div className={styles.adminWaitingMessage}>waiting for admin to decide what to do next...</div>
+          )}
         </div>
       </div>
     );

--- a/src/components/RankedChoiceVoting/index.tsx
+++ b/src/components/RankedChoiceVoting/index.tsx
@@ -165,12 +165,16 @@ function RankedChoiceVoting({ session }: { session: ISession }) {
           
           {allUsersVoted && isUserInSession && (
             <div className={styles.actionsContainer}>
-              <button
-                onClick={handleSendToResults}
-                className={styles.nextButton}
-              >
-                Complete Voting
-              </button>
+              {isAdmin ? (
+                <button
+                  onClick={handleSendToResults}
+                  className={styles.nextButton}
+                >
+                  Complete Voting
+                </button>
+              ) : (
+                <div className={styles.adminWaitingMessage}>waiting for admin to show results...</div>
+              )}
             </div>
           )}
           

--- a/src/components/SimpleVoting/index.tsx
+++ b/src/components/SimpleVoting/index.tsx
@@ -29,6 +29,8 @@ function SimpleVoting({ session }: { session: ISession }) {
     strategy: 'simple_vote'
   });
 
+  const isAdmin = userData.color === session.admin_color;
+
   if (sendToResults) {
     return null;
   }
@@ -52,22 +54,26 @@ function SimpleVoting({ session }: { session: ISession }) {
 
   // Bottom action content for after voting
   const bottomActionContent = showTieOptions ? (
-    <>
-      <button
-        className={`${styles.button}`}
-        onClick={startTiebreakerRound}
-        disabled={isLoading}
-      >
-        start tie-breaker round
-      </button>
-      <button
-        className={`${styles.button} ${styles.dark}`}
-        onClick={acceptMultipleWinners}
-        disabled={isLoading}
-      >
-        accept multiple winners
-      </button>
-    </>
+    isAdmin ? (
+      <>
+        <button
+          className={`${styles.button}`}
+          onClick={startTiebreakerRound}
+          disabled={isLoading}
+        >
+          start tie-breaker round
+        </button>
+        <button
+          className={`${styles.button} ${styles.dark}`}
+          onClick={acceptMultipleWinners}
+          disabled={isLoading}
+        >
+          accept multiple winners
+        </button>
+      </>
+    ) : (
+      <div className={styles.waitingMessage}>waiting for admin to decide what to do next...</div>
+    )
   ) : (
     <button
       className={`${styles.button} ${styles.dark}`}

--- a/src/components/SimpleVoting/index.tsx
+++ b/src/components/SimpleVoting/index.tsx
@@ -75,13 +75,17 @@ function SimpleVoting({ session }: { session: ISession }) {
       <div className={styles.waitingMessage}>waiting for admin to decide what to do next...</div>
     )
   ) : (
-    <button
-      className={`${styles.button} ${styles.dark}`}
-      onClick={handleSendToResults}
-      disabled={isLoading}
-    >
-      {isLoading ? "processing..." : "see results!"}
-    </button>
+    isAdmin ? (
+      <button
+        className={`${styles.button} ${styles.dark}`}
+        onClick={handleSendToResults}
+        disabled={isLoading}
+      >
+        {isLoading ? "processing..." : "see results!"}
+      </button>
+    ) : (
+      <div className={styles.waitingMessage}>waiting for admin to show results...</div>
+    )
   );
 
   return (

--- a/src/components/Voting/Voting.module.scss
+++ b/src/components/Voting/Voting.module.scss
@@ -174,4 +174,15 @@
 
 .bold {
   font-weight: bold;
+}
+
+.waitingMessage {
+  text-align: center;
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-style: italic;
+  padding: 0 20px;
+  max-width: 100%;
+  box-sizing: border-box;
 } 

--- a/src/components/Voting/useVotingLogic.tsx
+++ b/src/components/Voting/useVotingLogic.tsx
@@ -274,7 +274,7 @@ export function useVotingLogic({ session, userData, strategy }: UseVotingLogicPr
       ? JSON.parse(chosenFilm) // chosenFilm contains JSON rankings
       : { [chosenFilm]: 1 }; // Simple vote for the chosen film
     
-    const { error } = await supabase.rpc('cast_vote', {
+    const { error } = await supabase.rpc('cast_new_vote', {
       p_session_id: sessionId,
       p_user_color: userData.color,
       p_vote_data: voteData

--- a/src/components/Voting/useVotingLogic.tsx
+++ b/src/components/Voting/useVotingLogic.tsx
@@ -336,6 +336,12 @@ export function useVotingLogic({ session, userData, strategy }: UseVotingLogicPr
       return;
     }
 
+    if (!data) {
+      console.error('Elimination returned no data');
+      setIsLoading(false);
+      return;
+    }
+
     if (!data.success) {
       console.error('Elimination failed:', data.error);
       setIsLoading(false);
@@ -358,6 +364,10 @@ export function useVotingLogic({ session, userData, strategy }: UseVotingLogicPr
         // Update local state immediately for responsiveness
         setFilmsInRound(data.remaining as IFilm[]);
         break;
+      default:
+        console.error('Unexpected elimination status:', data.status);
+        setIsLoading(false);
+        return;
     }
 
     setChosenFilm('');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes voting flow and session start UX, with clearer admin control and backend RPCs.
> 
> - Replace direct table updates with RPCs: `cast_new_vote`, `process_simple_vote_round`, `process_elimination_round`, `start_tiebreaker_round`, with robust success/error/empty handling and tie outcomes
> - Gate post-vote actions to admins across Elimination/RankedChoice/Simple; non-admins see "waiting for admin" messages; preserve real-time-driven UI updates
> - Add "we're all here" confirmation modal in `ColorPicker` showing `voting_strategy` and `allowed_noms`; debounce auto-saving of settings
> - Enable Lobby interactions: allow starting a new session (validated ID generation) and joining by code with loading/disable states
> - Add/adjust styles for modal, admin/waiting messages, and minor layout tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3efff4ba85a18ad6bb93c3eb9afe1bc09cd1fde0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->